### PR TITLE
fix(context): restore stack-hassio artifact compatibility

### DIFF
--- a/context_generator/config.py
+++ b/context_generator/config.py
@@ -34,6 +34,11 @@ class GenerationConfig:
             raise ValueError("history_hours, log_hours and calendar_days cannot be negative")
         if self.max_output_bytes < 1024 or self.max_source_bytes < 1024:
             raise ValueError("generation size limits are too small")
+        if self.max_output_bytes > MAX_CONTEXT_ARTIFACT_BYTES:
+            raise ValueError(
+                "HA_CONTEXT_MAX_OUTPUT_BYTES exceeds the supported artifact size "
+                f"({MAX_CONTEXT_ARTIFACT_BYTES} bytes)"
+            )
 
     @property
     def network_enabled(self) -> bool:

--- a/context_generator/config.py
+++ b/context_generator/config.py
@@ -9,6 +9,7 @@ from typing import Literal
 
 GenerationMode = Literal["offline", "online", "hybrid"]
 DEFAULT_MAX_OUTPUT_BYTES = 96 * 1024 * 1024
+MAX_CONTEXT_ARTIFACT_BYTES = 128 * 1024 * 1024
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/protocol/test_security_boundaries_filesystem.py
+++ b/tests/protocol/test_security_boundaries_filesystem.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from context_generator.config import MAX_CONTEXT_ARTIFACT_BYTES
 from tools.security import PathPolicy, SecurityBoundaryError, resolve_output_path
 
 
@@ -76,3 +77,24 @@ def test_artifact_output_is_confined_and_typed(tmp_path: Path) -> None:
         resolve_output_path(tmp_path / "escape.md", root)
     with pytest.raises(SecurityBoundaryError):
         resolve_output_path(root / "context.sh", root)
+
+
+def test_context_artifact_at_shared_size_limit_is_accepted(tmp_path: Path) -> None:
+    root = tmp_path / "artifacts"
+    root.mkdir()
+    artifact = root / "context.md"
+    with artifact.open("wb") as stream:
+        stream.truncate(MAX_CONTEXT_ARTIFACT_BYTES)
+
+    assert resolve_output_path(artifact, root) == artifact
+
+
+def test_context_artifact_above_shared_size_limit_is_rejected(tmp_path: Path) -> None:
+    root = tmp_path / "artifacts"
+    root.mkdir()
+    artifact = root / "context.md"
+    with artifact.open("wb") as stream:
+        stream.truncate(MAX_CONTEXT_ARTIFACT_BYTES + 1)
+
+    with pytest.raises(SecurityBoundaryError, match="File too large"):
+        resolve_output_path(artifact, root)

--- a/tests/unit/test_context_size_contract.py
+++ b/tests/unit/test_context_size_contract.py
@@ -1,0 +1,35 @@
+"""Contract tests for configured context artifact sizes."""
+
+from pathlib import Path
+
+import pytest
+
+from context_generator.config import (
+    DEFAULT_MAX_OUTPUT_BYTES,
+    MAX_CONTEXT_ARTIFACT_BYTES,
+    GenerationConfig,
+)
+
+
+def _config(max_output_bytes: int) -> GenerationConfig:
+    return GenerationConfig(
+        config_path=Path("config"),
+        output_path=Path("output/context.md"),
+        ha_url="",
+        ha_token="",
+        max_output_bytes=max_output_bytes,
+    )
+
+
+def test_default_context_output_limit_remains_96_mib() -> None:
+    assert DEFAULT_MAX_OUTPUT_BYTES == 96 * 1024 * 1024
+    assert _config(DEFAULT_MAX_OUTPUT_BYTES).max_output_bytes == DEFAULT_MAX_OUTPUT_BYTES
+
+
+def test_context_output_limit_accepts_shared_maximum() -> None:
+    assert _config(MAX_CONTEXT_ARTIFACT_BYTES).max_output_bytes == MAX_CONTEXT_ARTIFACT_BYTES
+
+
+def test_context_output_limit_rejects_one_byte_above_shared_maximum() -> None:
+    with pytest.raises(ValueError, match="exceeds the supported artifact size"):
+        _config(MAX_CONTEXT_ARTIFACT_BYTES + 1)

--- a/tools/security.py
+++ b/tools/security.py
@@ -8,6 +8,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
+from context_generator.config import MAX_CONTEXT_ARTIFACT_BYTES
+
 
 class SecurityBoundaryError(PermissionError):
     """Raised when an input crosses a configured security boundary."""
@@ -155,10 +157,10 @@ class PathPolicy:
 
 
 def resolve_output_path(raw_path: str | Path, output_root: str | Path) -> Path:
-    """Resolve an artifact path below the configured output root."""
+    """Resolve a context artifact path below the configured output root."""
     policy = PathPolicy.from_paths(
         [Path(output_root)],
-        max_file_size=50 * 1024 * 1024,
+        max_file_size=MAX_CONTEXT_ARTIFACT_BYTES,
         max_depth=8,
         deny_storage=False,
     )

--- a/tools/security.py
+++ b/tools/security.py
@@ -157,7 +157,15 @@ class PathPolicy:
 
 
 def resolve_output_path(raw_path: str | Path, output_root: str | Path) -> Path:
-    """Resolve a context artifact path below the configured output root."""
+    """Resolve a context artifact path below the configured output root.
+
+    Args:
+        raw_path: Candidate artifact path to validate and resolve.
+        output_root: Configured root that must contain the artifact.
+
+    Returns:
+        The resolved artifact path within the configured output root.
+    """
     policy = PathPolicy.from_paths(
         [Path(output_root)],
         max_file_size=MAX_CONTEXT_ARTIFACT_BYTES,


### PR DESCRIPTION
## Summary

Fixes the context artifact size contract used by the authenticated REST compatibility API consumed by `stack-hassio`.

## Root cause

The context generator permits up to 96 MiB by default, while `tools.security.resolve_output_path()` had a separate 50 MiB cap. This allowed generation and download to disagree about what a valid artifact is. It also made the old ~98 MiB artifact from the pre-bounding implementation capable of blocking a subsequent generation before atomic replacement.

## Change

- define a shared maximum supported context artifact capacity of 128 MiB;
- keep the normal generator default at 96 MiB;
- reject operator configuration above the shared capacity;
- make the artifact resolver use the same shared capacity instead of a separate 50 MiB limit.

This keeps a finite fail-closed artifact bound while ensuring every generator-supported output is also valid for the REST download path. Bearer authentication is unchanged and remains required; `stack-hassio` commit `0fe88b1` supplies the token/header side of the integration.

## Validation

Full exact-head repository CI is required before this PR is marked ready. The branch is intentionally draft until validation and release-note/test follow-up are complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the maximum supported context artifact size to 128 MiB.
  * Added validation with a clear error message when configured output exceeds the limit.
  * Updated output path handling to consistently enforce the new size limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->