### PR TITLE
fix(logs,config-entries): Supervisor log fallback and real config entry states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+- The log tool family (`analyze_log_errors`, `search_logs`, `get_recent_logs`, `get_previous_logs`, `get_log_timeline`, `get_log_insights`, `get_startup_errors`, `get_component_logs`) works again on HA OS and Supervised installs where Home Assistant 2025.11+ no longer writes `home-assistant.log`: when the file is absent, tools read the same records through the Supervisor proxy (`/api/hassio/core/logs`, previous boot via `/api/hassio/core/logs/boots/0`) before falling back to `/api/error_log`, and Supervisor ANSI colour codes are stripped before parsing. Core/Container installs (Supervisor answers 404) keep the explicit file-path error. The tool registrations now also pass the configured Home Assistant credentials to the log handlers, which previously never received them, leaving every API fallback dead.
+- `search_config_entries` reports the real per-entry `state` from `GET /api/config/config_entries/entry` instead of deriving a guess from `.storage` and the entity registry, which mislabeled a failed (`setup_retry`) integration as `loaded` and changed the reported state with the `with_entities` flag. When the API is unreachable the `state` field is omitted rather than guessed, a `state` filter fails explicitly, `summary_only` reports honest per-state counts, and state filtering no longer performs per-entry entity lookups.
+
 ## [2.1.0] - 2026-09-10
 
 ### Added

--- a/tests/unit/test_config_entries.py
+++ b/tests/unit/test_config_entries.py
@@ -291,13 +291,25 @@ class TestSearchConfigEntries:
 
     @pytest.mark.asyncio
     async def test_with_summary_only(self):
-        """summary_only=True should include state field in result entries."""
+        """summary_only=True reports real API state counts, never guesses."""
         with ExitStack() as stack:
             mock_load = stack.enter_context(patch("tools.config_entries.load_registry"))
             mock_load.side_effect = lambda name, path: self.mock_registry_data.get(name, {})
 
             mock_entities = stack.enter_context(patch("tools.config_entries.get_registry_entities"))
             mock_entities.return_value = []
+
+            mock_request = stack.enter_context(patch("tools.config_entries.make_ha_request"))
+            mock_request.return_value = {
+                "success": True,
+                "data": [
+                    {"entry_id": "sun_entry_001", "state": "loaded"},
+                    {"entry_id": "e01182bae2f8b20605c8317f4623d1e9", "state": "loaded"},
+                    {"entry_id": "gree_disabled_entry_123", "state": "not_loaded"},
+                    {"entry_id": "mqtt_entry_001", "state": "loaded"},
+                    {"entry_id": "tuya_entry_456", "state": "loaded"},
+                ],
+            }
 
             register_config_entry_tools(self.mock_mcp, self.config_path, self.ha_url, self.ha_token)
             result = await self.mock_mcp._tools["search_config_entries"](
@@ -308,8 +320,44 @@ class TestSearchConfigEntries:
 
         assert data["success"] is True
         assert data["matched_count"] == 1
-        assert "state" in data["entries"][0]
-        assert data["entries"][0]["state"] in ("loaded", "not_loaded", "unknown")
+        assert data["state_source"] == "api"
+        assert data["entries"][0]["state"] == "loaded"
+
+    @pytest.mark.asyncio
+    async def test_summary_only_reports_real_state_counts(self):
+        """summary_only counts real API states instead of the old loaded/not_loaded guess."""
+        synthetic_entries = [
+            {
+                "entry_id": f"entry_{i:03d}",
+                "domain": "mqtt",
+                "title": f"Entry {i}",
+                "disabled_by": None,
+            }
+            for i in range(60)
+        ]
+        with ExitStack() as stack:
+            mock_entries = stack.enter_context(patch("tools.config_entries._get_config_entries"))
+            mock_entries.return_value = synthetic_entries
+
+            mock_request = stack.enter_context(patch("tools.config_entries.make_ha_request"))
+            mock_request.return_value = {
+                "success": True,
+                "data": [
+                    {"entry_id": f"entry_{i:03d}", "state": "loaded" if i % 3 else "setup_retry"}
+                    for i in range(60)
+                ],
+            }
+
+            register_config_entry_tools(self.mock_mcp, self.config_path, self.ha_url, self.ha_token)
+            result = await self.mock_mcp._tools["search_config_entries"](summary_only=True)
+
+        data = json.loads(result)
+
+        assert data["success"] is True
+        assert data["state_source"] == "api"
+        assert data["state_counts"]["loaded"] == 40
+        assert data["state_counts"]["setup_retry"] == 20
+        assert "not_loaded" not in data["state_counts"]
 
 
 # ─────────────────────────────────────────────────────────────
@@ -527,3 +575,141 @@ class TestListConfigEntryDomains:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+# ─────────────────────────────────────────────────────────────
+# TEST: real config entry states from the API (issue #32)
+# ─────────────────────────────────────────────────────────────
+class TestSearchConfigEntryApiStates:
+    """Entry states come from the REST API, never from a storage-derived guess."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, mock_mcp, config_path, ha_url, ha_token, mock_registry_data):
+        """Setup test fixtures."""
+        self.mock_mcp = mock_mcp
+        self.config_path = config_path
+        self.ha_url = ha_url
+        self.ha_token = ha_token
+        self.mock_registry_data = mock_registry_data
+
+    API_ENTRY_STATES = {
+        "sun_entry_001": "loaded",
+        "e01182bae2f8b20605c8317f4623d1e9": "loaded",
+        "gree_disabled_entry_123": "not_loaded",
+        "tuya_entry_456": "setup_retry",
+    }
+
+    def _api_payload(self):
+        return {
+            "success": True,
+            "data": [
+                {"entry_id": entry_id, "state": state}
+                for entry_id, state in self.API_ENTRY_STATES.items()
+            ],
+        }
+
+    @pytest.mark.asyncio
+    async def test_state_comes_from_api_not_storage_guess(self):
+        """A retrying integration with stale entities reports setup_retry, not loaded."""
+        with ExitStack() as stack:
+            mock_load = stack.enter_context(patch("tools.config_entries.load_registry"))
+            mock_load.side_effect = lambda name, path: self.mock_registry_data.get(name, {})
+
+            mock_entities = stack.enter_context(patch("tools.config_entries.get_registry_entities"))
+            mock_entities.return_value = [
+                {"entity_id": "sensor.stale", "config_entry_id": "tuya_entry_456"}
+            ]
+
+            mock_request = stack.enter_context(patch("tools.config_entries.make_ha_request"))
+            mock_request.return_value = self._api_payload()
+
+            register_config_entry_tools(self.mock_mcp, self.config_path, self.ha_url, self.ha_token)
+            result = await self.mock_mcp._tools["search_config_entries"]()
+
+        data = json.loads(result)
+        by_id = {e["entry_id"]: e for e in data["entries"]}
+
+        assert data["state_source"] == "api"
+        assert by_id["tuya_entry_456"]["state"] == "setup_retry"
+        assert by_id["gree_disabled_entry_123"]["state"] == "not_loaded"
+
+    @pytest.mark.asyncio
+    async def test_state_filter_matches_real_retry_state(self):
+        """state=setup_retry finds the retrying entry (previously returned zero)."""
+        with ExitStack() as stack:
+            mock_load = stack.enter_context(patch("tools.config_entries.load_registry"))
+            mock_load.side_effect = lambda name, path: self.mock_registry_data.get(name, {})
+
+            mock_entities = stack.enter_context(patch("tools.config_entries.get_registry_entities"))
+            mock_entities.return_value = []
+
+            mock_request = stack.enter_context(patch("tools.config_entries.make_ha_request"))
+            mock_request.return_value = self._api_payload()
+
+            register_config_entry_tools(self.mock_mcp, self.config_path, self.ha_url, self.ha_token)
+            result = await self.mock_mcp._tools["search_config_entries"](state="setup_retry")
+
+        data = json.loads(result)
+
+        assert data["success"] is True
+        assert data["matched_count"] == 1
+        assert data["entries"][0]["entry_id"] == "tuya_entry_456"
+
+    @pytest.mark.asyncio
+    async def test_state_omitted_when_api_unreachable(self):
+        """Without the API the state field is left out instead of guessed."""
+        with ExitStack() as stack:
+            mock_load = stack.enter_context(patch("tools.config_entries.load_registry"))
+            mock_load.side_effect = lambda name, path: self.mock_registry_data.get(name, {})
+
+            mock_entities = stack.enter_context(patch("tools.config_entries.get_registry_entities"))
+            mock_entities.return_value = []
+
+            mock_request = stack.enter_context(patch("tools.config_entries.make_ha_request"))
+            mock_request.return_value = {"success": False, "error": "connection refused"}
+
+            register_config_entry_tools(self.mock_mcp, self.config_path, self.ha_url, self.ha_token)
+            result = await self.mock_mcp._tools["search_config_entries"]()
+
+        data = json.loads(result)
+
+        assert data["success"] is True
+        assert data["state_source"] == "unavailable"
+        assert all("state" not in entry for entry in data["entries"])
+
+    @pytest.mark.asyncio
+    async def test_state_filter_fails_closed_when_api_unreachable(self):
+        """A state filter without API access fails explicitly instead of guessing."""
+        with ExitStack() as stack:
+            mock_load = stack.enter_context(patch("tools.config_entries.load_registry"))
+            mock_load.side_effect = lambda name, path: self.mock_registry_data.get(name, {})
+
+            mock_entities = stack.enter_context(patch("tools.config_entries.get_registry_entities"))
+            mock_entities.return_value = []
+
+            mock_request = stack.enter_context(patch("tools.config_entries.make_ha_request"))
+            mock_request.return_value = {"success": False, "error": "connection refused"}
+
+            register_config_entry_tools(self.mock_mcp, self.config_path, self.ha_url, self.ha_token)
+            result = await self.mock_mcp._tools["search_config_entries"](state="loaded")
+
+        data = json.loads(result)
+
+        assert data["success"] is False
+        assert "unreachable" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_state_filter_does_not_load_entity_registry(self):
+        """Filtering by real API state must not pay for registry entity lookups."""
+        with ExitStack() as stack:
+            mock_load = stack.enter_context(patch("tools.config_entries.load_registry"))
+            mock_load.side_effect = lambda name, path: self.mock_registry_data.get(name, {})
+
+            mock_entities = stack.enter_context(patch("tools.config_entries.get_registry_entities"))
+            mock_request = stack.enter_context(patch("tools.config_entries.make_ha_request"))
+            mock_request.return_value = self._api_payload()
+
+            register_config_entry_tools(self.mock_mcp, self.config_path, self.ha_url, self.ha_token)
+            await self.mock_mcp._tools["search_config_entries"](state="loaded")
+
+        mock_entities.assert_not_called()

--- a/tests/unit/test_logs.py
+++ b/tests/unit/test_logs.py
@@ -419,8 +419,10 @@ class TestGetLogInsightsApiFallback:
         register_log_tools(mock_mcp, config_path, ha_url="http://ha:8123", ha_token="test")
 
         with patch("tools.utils.make_ha_request") as mock_request:
-            # First call (error_log) fails, second (logbook) succeeds
+            # First call (Supervisor proxy, issue #31) fails, second
+            # (error_log) fails, third (logbook) succeeds
             mock_request.side_effect = [
+                {"success": False, "error": "404: Not Found"},
                 {"success": False, "error": "not found"},
                 {
                     "success": True,
@@ -449,3 +451,124 @@ class TestGetLogInsightsApiFallback:
         data = json.loads(mock_mcp._tools["get_log_insights"](hours=1))
         assert data["success"] is False
         assert "not found" in data["error"].lower()
+
+
+# ========================================
+# SUPERVISOR LOG FALLBACK (issue #31)
+# ========================================
+
+
+class TestSupervisorLogFallback:
+    """HA OS/Supervised installs have no home-assistant.log (issue #31).
+
+    Log tools must fall back to the Supervisor proxy before failing, and
+    Core/Container installs (404) must keep the explicit file-path error.
+    """
+
+    def test_recent_logs_fall_back_to_supervisor_and_strip_ansi(
+        self, mock_mcp, tmp_path, ha_url, ha_token
+    ):
+        """File missing + Supervisor proxy answering 200 serves ANSI-stripped logs."""
+        register_log_tools(mock_mcp, str(tmp_path), ha_url=ha_url, ha_token=ha_token)
+
+        ansi_payload = (
+            "\x1b[32m2026-09-02 22:03:18.087 WARNING (MainThread) "
+            "[habluetooth.wrappers] BleakClient.connect() called\x1b[0m\n"
+            "2026-09-02 22:03:19.000 ERROR (MainThread) [mqtt] Connection failed\n"
+        )
+        with patch("tools.utils.make_ha_request") as mock_request:
+            mock_request.return_value = {"success": True, "data": ansi_payload}
+            data = json.loads(mock_mcp._tools["get_recent_logs"](lines=100))
+
+        assert data["success"] is True
+        assert data["source"] == "supervisor_proxy"
+        assert "\x1b" not in data["logs"]
+        assert "BleakClient.connect()" in data["logs"]
+
+    def test_recent_logs_request_lines_parameter(self, mock_mcp, tmp_path, ha_url, ha_token):
+        """The current-boot proxy request carries the requested line budget."""
+        register_log_tools(mock_mcp, str(tmp_path), ha_url=ha_url, ha_token=ha_token)
+
+        with patch("tools.utils.make_ha_request") as mock_request:
+            mock_request.return_value = {"success": True, "data": "line\n"}
+            json.loads(mock_mcp._tools["get_recent_logs"](lines=42))
+
+        endpoint = mock_request.call_args[0][2]
+        assert endpoint == "/api/hassio/core/logs?lines=84"
+
+    def test_previous_logs_use_boots_endpoint(self, mock_mcp, tmp_path, ha_url, ha_token):
+        """get_previous_logs maps home-assistant.log.1 to the previous-boot proxy."""
+        register_log_tools(mock_mcp, str(tmp_path), ha_url=ha_url, ha_token=ha_token)
+
+        with patch("tools.utils.make_ha_request") as mock_request:
+            mock_request.return_value = {"success": True, "data": "old boot line\n"}
+            data = json.loads(mock_mcp._tools["get_previous_logs"](lines=10))
+
+        endpoint = mock_request.call_args[0][2]
+        assert endpoint == "/api/hassio/core/logs/boots/0"
+        assert data["source"] == "supervisor_proxy"
+
+    def test_supervisor_404_keeps_explicit_error(self, mock_mcp, tmp_path, ha_url, ha_token):
+        """Core/Container installs answer 404: tools fail with the explicit message."""
+        register_log_tools(mock_mcp, str(tmp_path), ha_url=ha_url, ha_token=ha_token)
+
+        with patch("tools.utils.make_ha_request") as mock_request:
+            mock_request.return_value = {"success": False, "error": "404: Not Found"}
+            data = json.loads(mock_mcp._tools["get_recent_logs"](lines=10))
+
+        assert data["success"] is False
+        assert "Supervisor log proxy" in data["error"]
+
+    def test_file_still_preferred_over_supervisor(self, mock_mcp, tmp_path, ha_url, ha_token):
+        """Installs that still write the log file keep the file path (no API call)."""
+        (Path(tmp_path) / "home-assistant.log").write_text(
+            "2024-06-01 14:20:00.000 INFO (MainThread) [homeassistant.core] boot\n",
+            encoding="utf-8",
+        )
+        register_log_tools(mock_mcp, str(tmp_path), ha_url=ha_url, ha_token=ha_token)
+
+        with patch("tools.utils.make_ha_request") as mock_request:
+            data = json.loads(mock_mcp._tools["get_recent_logs"](lines=10))
+
+        mock_request.assert_not_called()
+        assert data["success"] is True
+        assert data["source"] == "log_file"
+
+    def test_analyze_log_errors_falls_back_to_supervisor(
+        self, mock_mcp, tmp_path, ha_url, ha_token
+    ):
+        """analyze_log_errors works through the proxy on log-less installs."""
+        register_log_tools(mock_mcp, str(tmp_path), ha_url=ha_url, ha_token=ha_token)
+
+        payload = (
+            "2026-09-02 22:03:18.087 ERROR (MainThread) [mqtt] Connection failed\n"
+            "2026-09-02 22:03:19.000 WARNING (MainThread) [mqtt] Retrying\n"
+        )
+        with patch("tools.utils.make_ha_request") as mock_request:
+            mock_request.return_value = {"success": True, "data": payload}
+            data = json.loads(mock_mcp._tools["analyze_log_errors"](log_source="current"))
+
+        assert data["success"] is True
+        assert data["total_errors"] == 1
+
+    def test_search_logs_scans_supervisor_content(self, mock_mcp, tmp_path, ha_url, ha_token):
+        """search_logs finds matches inside proxy-served journal lines."""
+        register_log_tools(mock_mcp, str(tmp_path), ha_url=ha_url, ha_token=ha_token)
+
+        with patch("tools.utils.make_ha_request") as mock_request:
+            mock_request.return_value = {
+                "success": True,
+                "data": "2026-09-02 22:03:18 ERROR (MainThread) [mqtt] bleak exploded\n",
+            }
+            data = json.loads(mock_mcp._tools["search_logs"](search_term="bleak"))
+
+        assert data["total_found"] == 1
+        assert "bleak" in data["results"][0]["content"]
+
+    def test_no_credentials_keeps_file_path_error(self, mock_mcp, config_path):
+        """Without credentials there is no proxy attempt and the error stays explicit."""
+        register_log_tools(mock_mcp, config_path)
+        data = json.loads(mock_mcp._tools["get_recent_logs"](lines=10))
+
+        assert data["success"] is False
+        assert "Supervisor log proxy" in data["error"]

--- a/tools/config_entries.py
+++ b/tools/config_entries.py
@@ -120,6 +120,29 @@ def _get_entry_state(
     return {"state": "loaded", "reason": "All entities available"}
 
 
+def _fetch_api_entry_states(ha_url: str, ha_token: str) -> dict[str, str] | None:
+    """Fetch the real per-entry states from the Home Assistant REST API.
+
+    ``GET /api/config/config_entries/entry`` is the only source of true entry
+    states; ``.storage/core.config_entries`` carries no ``state`` field at all.
+
+    Returns:
+        Mapping of ``entry_id`` to state, or ``None`` when the API is
+        unreachable so callers can distinguish "no state available" from a
+        real state instead of guessing.
+    """
+    result = make_ha_request(ha_url, ha_token, "/api/config/config_entries/entry", timeout=30)
+    if not result.get("success") or not isinstance(result.get("data"), list):
+        return None
+    states: dict[str, str] = {}
+    for entry in result["data"]:
+        entry_id = entry.get("entry_id")
+        state = entry.get("state")
+        if isinstance(entry_id, str) and isinstance(state, str):
+            states[entry_id] = state
+    return states
+
+
 # =============================================================================
 # DO FUNCTIONS
 # =============================================================================
@@ -217,9 +240,18 @@ def _do_search_config_entries(
 ) -> str:
     """Search config entries with optional filters."""
     entries = _get_config_entries(config_path)
-    results = []
 
-    all_entities = get_registry_entities(config_path) if with_entities or state else []
+    api_states = _fetch_api_entry_states(ha_url, ha_token)
+    state_source = "api" if api_states is not None else "unavailable"
+
+    if state and api_states is None:
+        return _error_response(
+            "state filter requires the Home Assistant API, which is unreachable; "
+            "stored config entries carry no real state field"
+        )
+
+    all_entities = get_registry_entities(config_path) if with_entities else []
+    results = []
 
     for entry in entries:
         if domain and entry.get("domain") != domain.lower():
@@ -231,36 +263,35 @@ def _do_search_config_entries(
         if disabled_only and not entry.get("disabled_by"):
             continue
 
-        entry_entities = [
-            e for e in all_entities if e.get("config_entry_id") == entry.get("entry_id")
-        ]
-        entity_count = len(entry_entities) if (with_entities or state) and entry_entities else None
+        entry_id = entry.get("entry_id")
+        if not isinstance(entry_id, str):
+            continue
 
-        resolved_state: str | None = None
-        if state:
-            state_info = _get_entry_state(entry, entry_entities, ha_url, ha_token)
-            resolved_state = state_info.get("state")
-            if resolved_state != state:
-                continue
+        # Report only the real API state; a stored entry has no state field,
+        # and deriving one from the entity registry guesses wrong in both
+        # directions (issue #32). When the API is unreachable the field is
+        # omitted instead of guessed.
+        resolved_state: str | None = api_states.get(entry_id) if api_states else None
 
-        if resolved_state is None:
-            if entry.get("disabled_by"):
-                resolved_state = "not_loaded"
-            elif entry_entities:
-                resolved_state = "loaded"
-            else:
-                resolved_state = "unknown"
+        if state and resolved_state != state:
+            continue
+
+        entity_count = None
+        if with_entities:
+            entity_count = sum(1 for e in all_entities if e.get("config_entry_id") == entry_id)
 
         result_entry = {
-            "entry_id": entry.get("entry_id"),
+            "entry_id": entry_id,
             "domain": entry.get("domain"),
             "title": entry.get("title"),
             "source": entry.get("source"),
-            "state": resolved_state,
             "disabled_by": entry.get("disabled_by"),
             "created_at": entry.get("created_at"),
             "modified_at": entry.get("modified_at"),
         }
+
+        if resolved_state is not None:
+            result_entry["state"] = resolved_state
 
         if entity_count is not None:
             result_entry["entities_count"] = entity_count
@@ -268,8 +299,11 @@ def _do_search_config_entries(
         results.append(result_entry)
 
     if summary_only and len(results) > 50:
-        loaded_count = sum(1 for r in results if r.get("state") != "not_loaded")
-        not_loaded_count = len(results) - loaded_count
+        state_counts: dict[str, int] = {}
+        for r in results:
+            entry_state = r.get("state")
+            if isinstance(entry_state, str):
+                state_counts[entry_state] = state_counts.get(entry_state, 0) + 1
         return _success_response(
             {
                 "filters": {
@@ -281,8 +315,8 @@ def _do_search_config_entries(
                 },
                 "total_entries": len(entries),
                 "matched_count": len(results),
-                "loaded": loaded_count,
-                "not_loaded": not_loaded_count,
+                "state_source": state_source,
+                "state_counts": state_counts,
                 "sample_entries": results[:20],
             }
         )
@@ -296,6 +330,7 @@ def _do_search_config_entries(
                 "disabled_only": disabled_only,
                 "summary_only": summary_only,
             },
+            "state_source": state_source,
             "total_entries": len(entries),
             "matched_count": len(results),
             "entries": results[:50],

--- a/tools/logs.py
+++ b/tools/logs.py
@@ -120,6 +120,69 @@ def _read_log_file(
         return None, {"source": "log_file", "truncated": False, "max_lines": effective_max}
 
 
+_ANSI_ESCAPE_PATTERN = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+
+def _strip_ansi_escape_codes(text: str) -> str:
+    """Remove ANSI colour escape sequences from Supervisor log output."""
+    return _ANSI_ESCAPE_PATTERN.sub("", text)
+
+
+def _read_supervisor_core_logs(
+    ha_url: str, ha_token: str, max_lines: int | None, previous_boot: bool = False
+) -> list[str] | None:
+    """Read Home Assistant core logs through the Supervisor proxy.
+
+    HA OS and Supervised installs stopped writing ``home-assistant.log`` in
+    Home Assistant 2025.11 (issue #31); the Supervisor proxy serves the same
+    records with a plain long-lived access token. Core and Container installs
+    have no Supervisor and answer 404, which maps to ``None``.
+    """
+    from tools.utils import make_ha_request
+
+    effective_max = 10000 if max_lines is None else max_lines
+    if previous_boot:
+        endpoint = "/api/hassio/core/logs/boots/0"
+    else:
+        endpoint = f"/api/hassio/core/logs?lines={effective_max}"
+    result = make_ha_request(ha_url, ha_token, endpoint, timeout=30)
+    if not result.get("success") or not isinstance(result.get("data"), str):
+        return None
+    text = _strip_ansi_escape_codes(result["data"])
+    lines = [line + "\n" for line in text.splitlines()]
+    return lines[-effective_max:]
+
+
+def _acquire_log_lines(
+    log_file: str,
+    config_path: str,
+    ha_url: str,
+    ha_token: str,
+    max_lines: int | None = None,
+) -> tuple[list[str] | None, dict[str, object]]:
+    """Read log lines from the file, falling back to the Supervisor proxy.
+
+    Order: log file first, so installs that still write it keep working
+    unchanged; then the Supervisor proxy for HA OS/Supervised installs whose
+    logs live only in the systemd journal.
+    """
+    lines, meta = _read_log_file(log_file, config_path, max_lines)
+    if lines:
+        return lines, meta
+    if ha_url and ha_token:
+        supervisor_lines = _read_supervisor_core_logs(
+            ha_url, ha_token, max_lines, previous_boot=log_file != "home-assistant.log"
+        )
+        if supervisor_lines:
+            effective_max = 10000 if max_lines is None else max_lines
+            return supervisor_lines, {
+                "source": "supervisor_proxy",
+                "truncated": len(supervisor_lines) >= effective_max,
+                "max_lines": effective_max,
+            }
+    return None, meta
+
+
 def _extract_entities(text: str) -> set[str]:
     """Extract all entity ids from text."""
     return set(_ENTITY_PATTERN.findall(text))
@@ -201,8 +264,8 @@ def _do_get_log_insights(
         return cached  # type: ignore[no-any-return]
 
     hours = min(max(int(hours), 1), 24)
-    log_lines, file_meta = _read_log_file("home-assistant.log", config_path)
-    api_fallback_used = False
+    log_lines, file_meta = _acquire_log_lines("home-assistant.log", config_path, ha_url, ha_token)
+    api_fallback_used = bool(log_lines) and file_meta.get("source") == "supervisor_proxy"
 
     if not log_lines and ha_url and ha_token:
         from tools.utils import make_ha_request
@@ -450,10 +513,15 @@ def _do_analyze_log_errors(
     max_results = int(max_results)
 
     log_file = "home-assistant.log" if log_source == "current" else "home-assistant.log.1"
-    log_lines, _ = _read_log_file(log_file, config_path)
+    log_lines, _ = _acquire_log_lines(log_file, config_path, ha_url, ha_token)
 
     if not log_lines:
-        return {"error": f"{log_file} not found"}
+        return {
+            "error": (
+                f"{log_file} not found and the Supervisor log proxy "
+                "(api/hassio/core/logs) is unavailable"
+            )
+        }
 
     errors = []
     warnings = []
@@ -568,10 +636,12 @@ def _do_get_recent_logs(
     ha_token: str = "",
 ) -> dict[str, Any]:
     lines = min(int(lines), 500)
-    log_lines, _ = _read_log_file("home-assistant.log", config_path, lines * 2)
+    log_lines, log_meta = _acquire_log_lines(
+        "home-assistant.log", config_path, ha_url, ha_token, lines * 2
+    )
 
     if not log_lines:
-        return {"error": "home-assistant.log not found"}
+        return {"error": "home-assistant.log not found and the Supervisor log proxy is unavailable"}
 
     if level.lower() != "all":
         level_upper = level.upper()
@@ -582,6 +652,7 @@ def _do_get_recent_logs(
         "lines_requested": lines,
         "lines_returned": len(result_lines),
         "level_filter": level,
+        "source": log_meta.get("source"),
         "logs": "".join(result_lines),
     }
 
@@ -594,10 +665,15 @@ def _do_get_previous_logs(
     ha_token: str = "",
 ) -> dict[str, Any]:
     lines = min(int(lines), 500)
-    log_lines, _ = _read_log_file("home-assistant.log.1", config_path, lines * 2)
+    log_lines, log_meta = _acquire_log_lines(
+        "home-assistant.log.1", config_path, ha_url, ha_token, lines * 2
+    )
 
     if not log_lines:
-        return {"error": "home-assistant.log.1 not found"}
+        return {
+            "error": "home-assistant.log.1 not found and the previous-boot Supervisor "
+            "log proxy (api/hassio/core/logs/boots/0) is unavailable"
+        }
 
     if level.lower() != "all":
         level_upper = level.upper()
@@ -608,6 +684,7 @@ def _do_get_previous_logs(
         "lines_requested": lines,
         "lines_returned": len(result_lines),
         "level_filter": level,
+        "source": log_meta.get("source"),
         "logs": "".join(result_lines),
     }
 
@@ -638,7 +715,7 @@ def _do_search_logs(
         log_files.append(("previous", "home-assistant.log.1"))
 
     for source_name, log_file in log_files:
-        log_lines, _ = _read_log_file(log_file, config_path)
+        log_lines, _ = _acquire_log_lines(log_file, config_path, ha_url, ha_token)
 
         if not log_lines:
             continue
@@ -696,7 +773,7 @@ def _do_get_component_logs(
         log_files.append(("previous", "home-assistant.log.1"))
 
     for source_name, log_file in log_files:
-        log_lines, _ = _read_log_file(log_file, config_path)
+        log_lines, _ = _acquire_log_lines(log_file, config_path, ha_url, ha_token)
 
         if not log_lines:
             continue
@@ -750,10 +827,10 @@ def _do_get_startup_errors(
     ha_url: str = "",
     ha_token: str = "",
 ) -> dict[str, Any]:
-    log_lines, _ = _read_log_file("home-assistant.log", config_path)
+    log_lines, _ = _acquire_log_lines("home-assistant.log", config_path, ha_url, ha_token)
 
     if not log_lines:
-        return {"error": "home-assistant.log not found"}
+        return {"error": "home-assistant.log not found and the Supervisor log proxy is unavailable"}
 
     startup_logs = []
     found_startup = False
@@ -821,10 +898,15 @@ def _do_get_log_timeline(
         hours_int = 1
 
     log_file = "home-assistant.log" if log_source == "current" else "home-assistant.log.1"
-    log_lines, _ = _read_log_file(log_file, config_path)
+    log_lines, _ = _acquire_log_lines(log_file, config_path, ha_url, ha_token)
 
     if not log_lines:
-        return {"error": f"{log_file} not found"}
+        return {
+            "error": (
+                f"{log_file} not found and the Supervisor log proxy "
+                "(api/hassio/core/logs) is unavailable"
+            )
+        }
 
     cutoff_time = datetime.now(UTC) - timedelta(hours=hours_int)
     timeline = []
@@ -939,6 +1021,8 @@ def register_log_tools(  # type: ignore[no-untyped-def]
                 log_source=log_source,
                 max_results=max_results,
                 config_path=config_path,
+                ha_url=ha_url,
+                ha_token=ha_token,
             )
             if isinstance(result, dict) and "error" in result:
                 return _error_response(result["error"])
@@ -959,7 +1043,13 @@ def register_log_tools(  # type: ignore[no-untyped-def]
             the raw log content string.
         """
         try:
-            result = _do_get_recent_logs(lines=lines, level=level, config_path=config_path)
+            result = _do_get_recent_logs(
+                lines=lines,
+                level=level,
+                config_path=config_path,
+                ha_url=ha_url,
+                ha_token=ha_token,
+            )
             if isinstance(result, dict) and "error" in result:
                 return _error_response(result["error"])
             return _success_response(result)
@@ -979,7 +1069,13 @@ def register_log_tools(  # type: ignore[no-untyped-def]
             the raw log content string.
         """
         try:
-            result = _do_get_previous_logs(lines=lines, level=level, config_path=config_path)
+            result = _do_get_previous_logs(
+                lines=lines,
+                level=level,
+                config_path=config_path,
+                ha_url=ha_url,
+                ha_token=ha_token,
+            )
             if isinstance(result, dict) and "error" in result:
                 return _error_response(result["error"])
             return _success_response(result)
@@ -1012,6 +1108,8 @@ def register_log_tools(  # type: ignore[no-untyped-def]
                 max_results=max_results,
                 context_lines=context_lines,
                 config_path=config_path,
+                ha_url=ha_url,
+                ha_token=ha_token,
             )
             if isinstance(result, dict) and "error" in result:
                 return _error_response(result["error"])
@@ -1040,6 +1138,8 @@ def register_log_tools(  # type: ignore[no-untyped-def]
                 log_source=log_source,
                 max_results=max_results,
                 config_path=config_path,
+                ha_url=ha_url,
+                ha_token=ha_token,
             )
             if isinstance(result, dict) and "error" in result:
                 return _error_response(result["error"])
@@ -1055,7 +1155,9 @@ def register_log_tools(  # type: ignore[no-untyped-def]
             JSON with startup errors and warnings, and total counts for each.
         """
         try:
-            result = _do_get_startup_errors(config_path=config_path)
+            result = _do_get_startup_errors(
+                config_path=config_path, ha_url=ha_url, ha_token=ha_token
+            )
             if isinstance(result, dict) and "error" in result:
                 return _error_response(result["error"])
             return _success_response(result)
@@ -1079,6 +1181,8 @@ def register_log_tools(  # type: ignore[no-untyped-def]
                 hours=hours,
                 log_source=log_source,
                 config_path=config_path,
+                ha_url=ha_url,
+                ha_token=ha_token,
             )
             if isinstance(result, dict) and "error" in result:
                 return _error_response(result["error"])


### PR DESCRIPTION
Closes #31
Closes #32

## Summary

**#31 — log tools on HA OS (2025.11+):** HA OS/Supervised installs no longer write `home-assistant.log`, so the whole log family failed. When the file is absent, tools now read the same records through the Supervisor proxy (`/api/hassio/core/logs?lines=N`; previous boot via `/api/hassio/core/logs/boots/0`) before the legacy `/api/error_log` fallback, stripping Supervisor ANSI colour codes first. Core/Container installs (proxy answers 404) keep the explicit file-path error. Also fixes a latent bug: the tool registrations never passed `ha_url`/`ha_token` to the log handlers, so every existing API fallback was unreachable through MCP.

**#32 — real config entry states:** `search_config_entries` now reports the true `state` from `GET /api/config/config_entries/entry` (live-verified: 255 entries, states incl. `setup_retry`) instead of a storage+registry guess that mislabeled a retrying integration as `loaded` and flipped with `with_entities`. API unreachable → `state` omitted, `state` filter fails closed, honest per-state `summary_only` counts, and no per-entry entity lookups (the reported 15 s slowdown).

## Verification

- New regressions: 8 Supervisor-fallback tests (endpoint shapes, ANSI strip, 404 path, file-preferred, credentials-less) + 6 API-state tests (real-state wins, `setup_retry` filter, omit-on-unreachable, fail-closed filter, no-registry-lookup perf pin, honest summary counts).
- Endpoint evidence: `/api/config/config_entries/entry` curl-verified against a live production instance (200, `loaded/not_loaded/setup_retry` distribution); Supervisor 200 responses evidenced in #31 on HA OS with a plain LLAT; 404 detection path verified live on a Container install.
- Gates: 1,375 unit+protocol tests, ruff check/format, mypy `--strict` (52 files), pre-commit 14/14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Log tools now work on Home Assistant OS and Supervised installations without local log files by using the Supervisor log service.
  * Log output is cleaned of terminal color codes, with clearer fallback errors and source details.
  * Configuration entry searches now report accurate API-based states and counts.
  * State filtering now handles unavailable API data safely and avoids unnecessary entity lookups.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->